### PR TITLE
Add CI workflow for lint, build, and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - name: Lint all packages
+        run: npx nx run-many --target=lint --all
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - name: Build all packages
+        run: npm run build:all
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - name: Build all packages
+        run: npm run build:all
+
+      - name: Run tests
+        run: npx nx run-many --target=test --all


### PR DESCRIPTION
This PR adds a CI workflow that runs on push to \main\ and on pull requests. It currently has no automated testing/linting in CI -- the only workflows are release-related.

### What it does

- **Lint**: Runs \
px nx run-many --target=lint --all\ across all 22+ packages
- **Build** (typecheck): Runs \
pm run build:all\ to typecheck all packages via tsc
- **Test**: Runs \
px nx run-many --target=test --all\ across all packages

### Why

As a monorepo with 22+ MCP server packages for security products, automated CI validation on every push and PR is critical for maintaining quality and catching regressions early.